### PR TITLE
Fix Moodle app issue

### DIFF
--- a/admin/tool/mobile/classes/api.php
+++ b/admin/tool/mobile/classes/api.php
@@ -33,6 +33,7 @@ use lang_string;
 use curl;
 use core_qrcode;
 use stdClass;
+use filter_manager;
 
 /**
  * API exposed by tool_mobile, to be used mostly by external functions and the plugin settings.


### PR DESCRIPTION
Hi @michael-milette 

I've detected that this change needs to declare the usage of filter_manager, without that declaration Moodle throws an error when trying to log in from the Moodle app under certain circumstances.

This change fixes the issue for us on Moodle 4.4 and I guess that the same would happen on other branches;  I think it would also affect the already integrated main branch, and in that case a new issue should be created to fix the regression...